### PR TITLE
Removed default standaloneModule option. It is automatically computed…

### DIFF
--- a/src/defaultOptions.json
+++ b/src/defaultOptions.json
@@ -1,7 +1,6 @@
 {
   "filePathAsId": false,
   "browserPack": {
-    "standaloneModule": 0,
     "raw": true
   }
 }


### PR DESCRIPTION
… from `exports`