### PR TITLE
Removed file.baseDir in favor of just using cwd

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -19,45 +19,44 @@ function File(options, cwd) {
     };
   }
 
-  var currCwd = options.cwd || cwd || _cwd;
-  var baseDir = _cwd === currCwd ? currCwd : path.join(_cwd, currCwd);
+  cwd = options.cwd || cwd || _cwd;
+  cwd = _cwd === cwd || path.isAbsolute(cwd) ? cwd : path.join(_cwd, cwd);
 
   this.src = [];
   this.dest = null;
-  this.cwd = currCwd;
-  this.baseDir = baseDir;
+  this.cwd = cwd;
   configurator.configure(this, parseOptions(options));
 }
 
 File.prototype.setSrc = function(files) {
-  this.src = src(files, this.baseDir);
+  this.src = src(files, this.cwd);
   return this;
 };
 
 File.prototype.setDest = function(file) {
-  this.dest = dest(file, this.cwd);
+  this.dest = dest(file, _cwd);
   return this;
 };
 
-function create(files, cwd) {
+function list(files, base) {
   return utils.toArray(files).map(function(file) {
-    return new File(file, cwd);
+    return new File(file, base);
   });
 }
 
-function src(files, baseDir) {
+function src(files, base) {
   return utils.toArray(files).reduce(function(result, file) {
     var globResult = types.isString(file) ?
-      glob.sync(file, { cwd: baseDir, realpath: true }) :
+      glob.sync(file, { cwd: base, realpath: true }) :
       [file];
 
     return result.concat(globResult);
   }, []);
 }
 
-function dest(file, cwd) {
+function dest(file, base) {
   return types.isString(file) ?
-    path.isAbsolute(file) ? file : path.join(cwd, file) :
+    path.isAbsolute(file) ? file : path.join(base, file) :
     file;
 }
 
@@ -75,6 +74,6 @@ function parseOptions(options) {
 }
 
 module.exports = File;
-module.exports.create = create;
+module.exports.list = list;
 module.exports.src = src;
 module.exports.dest = dest;

--- a/test/spec/file.js
+++ b/test/spec/file.js
@@ -25,10 +25,6 @@ describe("File unit test", function() {
     it("then the current directory contains bit-bundler", function() {
       expect(result.cwd).to.contain("/bit-bundler");
     });
-
-    it("then the current directory is the same as the base directory", function() {
-      expect(result.cwd).to.be.equal(result.baseDir);
-    });
   });
 
   describe("When creating a File with only a string as the input", function() {
@@ -47,10 +43,6 @@ describe("File unit test", function() {
 
     it("then the current directory contains bit-bundler", function() {
       expect(result.cwd).to.contain("/bit-bundler");
-    });
-
-    it("then the current directory is the same as the base directory", function() {
-      expect(result.cwd).to.be.equal(result.baseDir);
     });
   });
 
@@ -74,10 +66,6 @@ describe("File unit test", function() {
 
     it("then the current directory contains bit-bundler", function() {
       expect(result.cwd).to.contain("/bit-bundler");
-    });
-
-    it("then the current directory is the same as the base directory", function() {
-      expect(result.cwd).to.be.equal(result.baseDir);
     });
   });
 
@@ -104,10 +92,6 @@ describe("File unit test", function() {
 
     it("then the current directory contains bit-bundler", function() {
       expect(result.cwd).to.contain("/bit-bundler");
-    });
-
-    it("then the current directory is the same as the base directory", function() {
-      expect(result.cwd).to.be.equal(result.baseDir);
     });
   });
 });


### PR DESCRIPTION
Now dest is always relative to process.cwd()