### PR TITLE
Omitting loader and bundler when logging the context.

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -61,7 +61,7 @@ Context.prototype.execute = function(files) {
     })
     .then(function(context) {
       bundleWriter(context.file.dest)(context);
-      logger.log("build-end", context);
+      logger.log("build-end", utils.omit(context, ["loader", "bundler"]));
       return context;
     });
 };


### PR DESCRIPTION
1. They are not really important to log
2. Logging bundler causes issues when serializing with JSON.stringify.