### PR TITLE
Buildstats stderr highjack

### DIFF
--- a/loggers/override-stream-write.js
+++ b/loggers/override-stream-write.js
@@ -1,0 +1,35 @@
+module.exports = function(stream, redirect) {
+  var _write = null;
+
+  var _instance = {
+    restore: restore,
+    override: override
+  };
+
+  return _instance;
+
+  function handler(data, encoding, cb) {
+    redirect.call(stream, data, encoding);
+
+    if (typeof encoding === "function") {
+      cb = encoding;
+      encoding = null;
+    }
+
+    if (typeof cb === "function") {
+      cb();
+    }
+  };
+
+  function restore() {
+    stream.write = _write;
+    _write = null;
+    return _instance;
+  }
+
+  function override() {
+    _write = stream.write;
+    stream.write = handler;
+    return _instance;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "test": "mocha --compilers js:babel-register"
   },
   "devDependencies": {
-    "babel-bits": "^1.0.1",
     "babel-core": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.24.1",


### PR DESCRIPTION
The purpose to properly handle console.log types of messages from causing spinner to render miscellaneous messages.  To handle that we highjack the process.stderr.write method and to intercept and handle messages while spinner are running.