### PR TITLE
Adds log2console dependency for 'hello world' example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ node_modules
 .lock-wscript
 
 .vscode
+
+# JetBrains IDE
+.idea

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -11,6 +11,7 @@
   "author": "Miguel Castillo <manchagnu@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "log2console": "^1.0.3"
   },
   "devDependencies": {
     "bit-bundler": "latest",


### PR DESCRIPTION
Looks like this is missing from the `package.json`.  

This PR adds it, along with an ignore rule for `.idea` dir.