### PR TITLE
Changed how options are loaded by bit-bundler so that loader-worker l…

### DIFF
--- a/examples/cache/.bitbundler.js
+++ b/examples/cache/.bitbundler.js
@@ -4,22 +4,23 @@
  * configuration is for caching data out to elasticsearch.
  */
 
-const redisConnector = require("bit-loader-cache/connectors/redis");
-// const esConnector = require("bit-loader-cache/connectors/elasticsearch");
+// const redisConnector = require("bit-loader-cache/connectors/redis");
+const esConnector = require("bit-loader-cache/connectors/elasticsearch");
 
 module.exports = {
   src: "src/main.js",
   dest: "dist/out.js",
+  multiprocess: 2,
 
   loader: [
     "bit-loader-babel",
     ["bit-loader-cache", {
-      connector: redisConnector()
-      // connector: esConnector({
-      //   host: "localhost:9200",
-      //   index: "cache_example",
-      //   type: "modules"
-      // })
+      // connector: redisConnector()
+      connector: esConnector({
+        host: "localhost:9200",
+        index: "cache_example",
+        type: "modules"
+      })
     }]
   ]
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "bit-bundler-browserpack": "^4.0.1",
     "bit-bundler-utils": "^5.0.1",
     "bit-loader": "^7.1.0",
-    "camelcase-keys": "^4.1.0",
     "chalk": "^2.3.0",
     "chokidar": "^1.7.0",
     "dis-isa": "^1.3.0",

--- a/src/cammelCaseKeys.js
+++ b/src/cammelCaseKeys.js
@@ -1,0 +1,24 @@
+module.exports = function camelcaseKeys(input) {
+  if (!input) {
+    return input;
+  }
+
+  var result;
+
+  if (input.constructor === Object) {
+    result = {};
+    Object.keys(input).forEach(key => result[toCamelcaseKeys(key)] = camelcaseKeys(input[key]));
+  }
+  else if (Array.isArray(input)) {
+    result = input.map(item => camelcaseKeys(item));
+  }
+  else {
+    result = input;
+  }
+
+  return result;
+};
+
+function toCamelcaseKeys(input) {
+  return input.replace(/\-\w/g, (match) => match.charAt(1).toUpperCase());
+}

--- a/src/loader/pool.js
+++ b/src/loader/pool.js
@@ -113,7 +113,7 @@ function createPool(loader, size) {
     worker.process.on("error", workerError);
 
     return worker
-      .invoke("init", loader.options)
+      .invoke("init")
       .catch(initError);
 
     function initError(error) {

--- a/src/loader/worker.js
+++ b/src/loader/worker.js
@@ -1,11 +1,12 @@
 "use strict";
 
-var Loader = require("./index");
-var Workit = require("workit");
-var es = require("event-stream");
+const Loader = require("./index");
+const Workit = require("workit");
+const es = require("event-stream");
+const options = require("../options")(process.argv.slice(2));
 
 class LoaderWorker extends Workit.Worker {
-  init(options, done) {
+  init() {
     this.loader = new Loader(Object.assign({}, options, {
       log: {
         stream: es.map((chunk, callback) => {
@@ -14,12 +15,12 @@ class LoaderWorker extends Workit.Worker {
         })
       }}));
 
-    done();
+    return Promise.resolve();
   }
 
-  clear(options, done) {
+  clear() {
     this.loader.clear();
-    done();
+    return Promise.resolve();
   }
 
   resolve(data) {

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -1,19 +1,19 @@
 const type = require("../type");
 const path = require("path");
-const camelcaseKeys = require("camelcase-keys");
 const subarg = require("subarg");
 const deprecated = require("./deprecated")("bit-bundler");
 const defaults = require("./defaults");
 const deprecatedOptions = require("./deprecated.json");
+const cammelCaseKeys = require("../cammelCaseKeys");
 
 module.exports = function parseCliOptions(args) {
-  const cliOptions = camelcaseKeys(subarg(args || []), { deep: true });
+  const cliOptions = cammelCaseKeys(subarg(args || []), { deep: true });
   const options = Object.assign({}, defaults, cliOptions);
   
   try {
     var configFilePath = path.join(process.cwd(), options.config);
     var configFile = require(configFilePath);
-    Object.assign(options, camelcaseKeys(configFile, { deep: true }));
+    Object.assign(options, cammelCaseKeys(configFile, { deep: true }));
   }
   catch(ex) {
     if (typeof options.config === "string") {


### PR DESCRIPTION
…oads its own configurations to prevent serielization issue that can occur when configurations are sent between parent process and child processes

The root cause of the issue is from `camelcase-keys` converting arrays to objects, which is tripping up how deep merge works.