### PR TITLE
added logic to completely disable logging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,7 @@ function configureLogger(bitbundler, options, loggerFactory) {
     };
   }
 
-  loggerFactory
+  const logger = loggerFactory
     .enableAll()
     .pipe(es.through(function(chunk) {
       chunk.name === "bundler/build" ?
@@ -165,8 +165,11 @@ function configureLogger(bitbundler, options, loggerFactory) {
         bitbundler.emit(chunk.name, chunk);
 
       this.emit("data", chunk);
-    }))
-    .pipe(options && options.stream ? options.stream : buildstats(options));
+    }));
+
+  if (options !== false) {
+    logger.pipe(options && options.stream ? options.stream : buildstats(options));
+  }
 }
 
 

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -36,7 +36,8 @@ module.exports = function parseCliOptions(args) {
     "watch": type.Boolean,
     "loader": type.Array.withTransform(toArray),
     "bundler": type.Array.withTransform(toArray),
-    "multiprocess": type.Any.withTransform(toNumberOrBoolean)
+    "multiprocess": type.Any.withTransform(toNumberOrBoolean),
+    "log": type.Any.withTransform(maybeBoolean)
   });
 
   function configureSrc(src) {
@@ -45,6 +46,18 @@ module.exports = function parseCliOptions(args) {
   
   function toArray(value) {
     return value && value._ ? value._ : [].concat(value);
+  }
+
+  function maybeBoolean(value) {
+    if (value === "false") {
+      return false;
+    }
+    else if (value === "true") {
+      return true;
+    }
+    else {
+      return value;
+    }    
   }
   
   function toNumberOrBoolean(value) {

--- a/test/spec/index.js
+++ b/test/spec/index.js
@@ -3,13 +3,12 @@
 import { expect } from "chai";
 import sinon from "sinon";
 import BitBundler from "../../src/index";
-import loggers from "../../loggers";
 
 describe("BitBundler test suite", function() {
   var createBundler, bitbundler;
 
   beforeEach(function() {
-    createBundler = (config) => bitbundler = new BitBundler(Object.assign({ log: { stream: loggers.through() } }, config || {}));
+    createBundler = (config) => bitbundler = new BitBundler(Object.assign({ log: false }, config || {}));
   });
 
   describe("When creating a bundler with no configuration", function() {


### PR DESCRIPTION
Now you can pass `log: false` or `--log false` to completely logging in bit-bundler