### PR TITLE
adding ability to generate bundles from file contents directly

### DIFF
--- a/src/bundle/builder.js
+++ b/src/bundle/builder.js
@@ -162,7 +162,7 @@ function getBrowserPackExports(bundler, bundle, context, bpOptions) {
 
 function createBrowserPackModule(mod) {
   return Object.assign({
-    sourceFile: path.relative(".", mod.path),
+    sourceFile: path.relative(".", mod.path || ""),
     deps: mod.deps.reduce((result, dep) => (result[dep.name] = dep.id, result), {})
   }, utils.pick(mod, ["id", "name", "path", "source"]));
 }

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ class Bitbundler extends EventEmitter {
     const bundler = this.bundler;
 
     return loader
-      .fetch(file.src)
+      .fetch(file)
       .then(() => {
         const cache = loader.getCache();
         const mainBundle = context.getBundles("main");

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -79,12 +79,24 @@ function configureDependency(options) {
   }, utils.pick(options, ["amd", "cjs"]));
 
   return function getDependencies(meta) {
-    if (meta.source && /[\w]+\.(js|jsx|mjs)$/.test(meta.path)) {
-      return {
-        deps: pullingDeps(meta.source, depsOptions).dependencies
-      };
+    if (meta.source && (checkExtensions(meta.path) || checkDependencies(meta.source))) {
+      try {
+        return {
+          deps: pullingDeps(meta.source, depsOptions).dependencies
+        };
+      }
+      catch(ex) {
+      }
     }
   };
+}
+
+function checkExtensions(path) {
+  return path && /[\w]+\.(js|jsx|mjs)$/.test(path);
+}
+
+function checkDependencies(source) {
+  return source && /\brequire|import\b/.test(source);
 }
 
 function buildError(title, meta) {

--- a/src/loader/worker.js
+++ b/src/loader/worker.js
@@ -28,11 +28,11 @@ class LoaderWorker extends Workit.Worker {
   }
 
   fetch(data) {
-    return this.loader.fetch(data.name, data.referrer);
+    return this.loader.fetch(data.file, data.referrer);
   }
 
   fetchShallow(data) {
-    return this.loader.fetchShallow(data.name, data.referrer);
+    return this.loader.fetchShallow(data.file, data.referrer);
   }
 }
 

--- a/test/spec/index.js
+++ b/test/spec/index.js
@@ -82,6 +82,44 @@ describe("BitBundler test suite", function() {
         .on("build-end", buildEnd);
     });
 
+    describe("And creating a bundle from javascript contents", function() {
+      beforeEach(function() {
+        return bitbundler.bundle({ contents: "console.log('hello world');" });
+      });
+
+      it("then emit is called with `build-init`", function() {
+        sinon.assert.calledWith(bitbundler.emit, "build-init");
+      });
+
+      it("then emit is called with `build-start`", function() {
+        sinon.assert.calledWith(bitbundler.emit, "build-start");
+      });
+
+      it("then initBuild event handler is called", function() {
+        sinon.assert.called(buildInit);
+      });
+
+      it("then preBuild event handler is called", function() {
+        sinon.assert.called(buildStart);
+      });
+
+      it("then postBuild event handler is called", function() {
+        sinon.assert.called(buildEnd);
+      });
+
+      it("then loader.hasModule is not called", function() {
+        sinon.assert.notCalled(bitbundler.loader.hasModule);
+      });
+
+      it("then loader.deleteModule is not called", function() {
+        sinon.assert.notCalled(bitbundler.loader.deleteModule);
+      });
+
+      it("then buildBundles is called with the corresponding contents", function() {
+        sinon.assert.calledWith(bitbundler.buildBundles, sinon.match.has("contents", "console.log('hello world');"));
+      });
+    });
+
     describe("And creating a bundle with one files", function() {
       beforeEach(function() {
         return bitbundler.bundle(["test/sample/X.js"]);


### PR DESCRIPTION
These changes introduce the ability to generate bundle by providing input javascript directly.

e.g.

``` javascript
bundle({ contents: "console.log('hello world');" });
```

You can also provide a path that will be used as the referrer path for resolving modules in the input javascript.

``` javascript
bundle({ contents: "require('./x.js');", path: "/Abosulte/path/to/resolve/x/from" })
```
