### PR TITLE
App bundle builder. Moving away from browser-pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "browser-pack": "^6.0.2",
     "chalk": "^2.3.0",
     "chokidar": "^2.0.0",
+    "combine-source-map": "^0.8.0",
     "dis-isa": "^1.3.0",
     "escodegen": "^1.9.0",
     "event-stream": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bit-bundler",
   "version": "10.1.0",
   "dependencies": {
+    "acorn": "^5.3.0",
     "belty": "^5.2.1",
     "bit-bundler-utils": "^5.1.2",
     "bit-loader": "^9.0.0",
@@ -9,6 +10,7 @@
     "chalk": "^2.3.0",
     "chokidar": "^2.0.0",
     "dis-isa": "^1.3.0",
+    "escodegen": "^1.9.0",
     "event-stream": "^3.3.4",
     "filesize": "^3.5.11",
     "log-symbols": "^2.1.0",
@@ -22,6 +24,7 @@
     "setopt": "^1.0.1",
     "src-dest": "^3.0.0",
     "subarg": "^1.0.0",
+    "umd": "^3.0.1",
     "workit": "^2.1.0"
   },
   "main": "src/index.js",

--- a/src/bundle/app-bundle-builder.js
+++ b/src/bundle/app-bundle-builder.js
@@ -1,50 +1,89 @@
+const cwd = process.cwd();
 const acorn = require("acorn");
 const walk = require("acorn/dist/walk");
-const escodegen = require("escodegen");
+// const escodegen = require("escodegen");
+const combineSourceMap = require("combine-source-map");
 const umd = require("umd");
 const prelude = require("./app-bundle-prelude").toString();
 const requireName = "_bb$req";
-const cwd = process.cwd();
+const preamble =`require=${requireName}=(${prelude})`;
 
-
-//
-// TODO: ADD SOURCE MAPS!!!
-//
-
-function buildBundle(modules, entries, options) {
+function buildBundle(modules, options) {
   options = options || {};
-  entries = entries || getEntries(modules);
-  const bundleString = `require=${requireName}=(${prelude})(${buildModuleMap(modules, entries)}, ${buildEntries(entries)});\n`;
-  return options.umd ? umd(options.umd, `${bundleString}return ${requireName}(${entries[0]});`) : bundleString;
-}
 
-function buildModuleMap(modules, entries) {
-  var visited = {}, result = [], currentId, deps, formattedDependencies;
+  const sourceMap = combineSourceMap.create();
+  const entries = options.entries || getEntries(modules);
+
+  var visited = {};
+  var result = [];
+  var lineno = lineCount(preamble) + (options.umd ? 1 : 0);
   var ids = entries.length ? entries.slice(0) : Object.keys(modules);
+  var id, currentModule, dependencies, formattedDependencies, formattedPreBundle, formattedPostBundle;
 
   for (var index = 0; index < ids.length; index++) {
-    currentId = ids[index];
+    id = ids[index];
 
-    if (visited[currentId] || !modules[currentId]) {
+    if (visited[id] || !modules[id]) {
       continue;
     }
 
-    visited[currentId] = true;
-    deps = modules[currentId].deps || [];
-    ids = ids.concat(deps.map(dep => dep.id || dep.path));
-    formattedDependencies = buildDependencies(deps);
-    result.push(`${getModuleInfo(modules[currentId], formattedDependencies)}\n${currentId}:[ ${wrapSource(modules[currentId])}, ${formattedDependencies}]`);
+    visited[id] = true;
+    currentModule = modules[id];
+    dependencies = currentModule.deps || [];
+    ids = ids.concat(dependencies.map(dep => dep.id || dep.path));
+
+    formattedDependencies = buildDependencies(dependencies);
+    formattedPreBundle = `${buildModuleInfoComment(currentModule, formattedDependencies)}\n${id}:`;
+    lineno += lineCount(formattedPreBundle);
+
+    sourceMap.addFile({
+      source: currentModule.source,
+      sourceFile: currentModule.path.replace(cwd, "")
+    }, {
+      line: lineno
+    });
+
+    formattedPostBundle = `[${wrapSource(combineSourceMap.removeComments(currentModule.source))}, ${formattedDependencies}]`;
+    lineno += lineCount(formattedPostBundle) - 1;
+    result.push(formattedPreBundle + formattedPostBundle);
   }
 
-  return `{\n${result.join(",\n")}\n}`;
+  const bundleString = `${preamble}({\n${result.join(",\n")}}, ${buildEntries(entries)});\n${sourceMap.comment()}`;
+  return options.umd ? umd(options.umd, `${bundleString}return ${requireName}(${entries[0]});`) : bundleString;
 }
 
-function wrapSource(mod) {
-  return `function(${requireName}, module, exports) {\n${renameRequire(mod)}\n}`;
+function wrapSource(source) {
+  return `function(${requireName}, module, exports) {\n${renameRequire(source)}\n}`;
 }
 
-function renameRequire(mod) {
-  const ast = acorn.parse(mod.source);
+function renameRequire(source) {
+  const result = source.split("");
+  const ast = acorn.parse(source);
+  var offset = 0;
+
+  walk.simple(ast, {
+    CallExpression: (node) => {
+      if (node.callee.name === "require") {
+        result.splice(node.callee.start - offset, node.callee.end - node.callee.start, requireName);
+        offset += 6;
+      }
+    }
+  });
+
+  return result.join("");
+}
+
+/*
+function renameRequireES(source) {
+  const comments = [], tokens = [];
+  const ast = acorn.parse(source, {
+    // collect ranges for each node
+    ranges: true,
+    // collect comments in Esprima's format
+    onComment: comments,
+    // collect token ranges
+    onToken: tokens
+  });
 
   walk.simple(ast, {
     CallExpression: (node) => {
@@ -54,8 +93,12 @@ function renameRequire(mod) {
     }
   });
 
-  return escodegen.generate(ast);
+  escodegen.attachComments(ast, comments, tokens);
+  return escodegen.generate(ast, {
+    comment: true
+  });
 }
+*/
 
 function buildDependencies(dependencies) {
   return "{" + dependencies.map(dependency => (`"${dependency.name}": ${dependency.id ? dependency.id : addQuotes(dependency.path)}`)).join(", ") + "}";
@@ -76,7 +119,7 @@ function addQuotes(item) {
   return `"${item}"`;
 }
 
-function getModuleInfo(mod, deps) {
+function buildModuleInfoComment(mod, deps) {
   return (
 `/**
  * id: ${mod.id}
@@ -84,6 +127,15 @@ function getModuleInfo(mod, deps) {
  * deps: ${deps}
  */`
   );
+}
+
+function lineCount(str) {
+  if (!str || !str.length) {
+    return 0;
+  }
+
+  const result = str.match(/\n/g);
+  return result ? result.length + 1: 1;
 }
 
 module.exports.buildBundle = buildBundle;

--- a/src/bundle/app-bundle-builder.js
+++ b/src/bundle/app-bundle-builder.js
@@ -1,7 +1,6 @@
 const cwd = process.cwd();
 const acorn = require("acorn");
 const walk = require("acorn/dist/walk");
-// const escodegen = require("escodegen");
 const combineSourceMap = require("combine-source-map");
 const umd = require("umd");
 const prelude = require("./app-bundle-prelude").toString();
@@ -48,8 +47,8 @@ function buildBundle(modules, options) {
     result.push(formattedPreBundle + formattedPostBundle);
   }
 
-  const bundleString = `${preamble}({\n${result.join(",\n")}}, ${buildEntries(entries)});\n${sourceMap.comment()}`;
-  return options.umd ? umd(options.umd, `${bundleString}return ${requireName}(${entries[0]});`) : bundleString;
+  const bundleString = `${preamble}({\n${result.join(",\n")}}, ${buildEntries(entries)});`;
+  return options.umd ? umd(options.umd, `${bundleString}\nreturn ${requireName}(${entries[0]});\n${sourceMap.comment()}`) : `${bundleString}\n${sourceMap.comment()}`;
 }
 
 function wrapSource(source) {
@@ -72,33 +71,6 @@ function renameRequire(source) {
 
   return result.join("");
 }
-
-/*
-function renameRequireES(source) {
-  const comments = [], tokens = [];
-  const ast = acorn.parse(source, {
-    // collect ranges for each node
-    ranges: true,
-    // collect comments in Esprima's format
-    onComment: comments,
-    // collect token ranges
-    onToken: tokens
-  });
-
-  walk.simple(ast, {
-    CallExpression: (node) => {
-      if (node.callee.name === "require") {
-        node.callee.name = requireName;
-      }
-    }
-  });
-
-  escodegen.attachComments(ast, comments, tokens);
-  return escodegen.generate(ast, {
-    comment: true
-  });
-}
-*/
 
 function buildDependencies(dependencies) {
   return "{" + dependencies.map(dependency => (`"${dependency.name}": ${dependency.id ? dependency.id : addQuotes(dependency.path)}`)).join(", ") + "}";

--- a/src/bundle/app-bundle-builder.js
+++ b/src/bundle/app-bundle-builder.js
@@ -1,0 +1,89 @@
+const acorn = require("acorn");
+const walk = require("acorn/dist/walk");
+const escodegen = require("escodegen");
+const umd = require("umd");
+const prelude = require("./app-bundle-prelude").toString();
+const requireName = "_bb$req";
+const cwd = process.cwd();
+
+
+//
+// TODO: ADD SOURCE MAPS!!!
+//
+
+function buildBundle(modules, entries, options) {
+  options = options || {};
+  entries = entries || getEntries(modules);
+  const bundleString = `require=${requireName}=(${prelude})(${buildModuleMap(modules, entries)}, ${buildEntries(entries)});\n`;
+  return options.umd ? umd(options.umd, `${bundleString}return ${requireName}(${entries[0]});`) : bundleString;
+}
+
+function buildModuleMap(modules, entries) {
+  var visited = {}, result = [], currentId, deps, formattedDependencies;
+  var ids = entries.length ? entries.slice(0) : Object.keys(modules);
+
+  for (var index = 0; index < ids.length; index++) {
+    currentId = ids[index];
+
+    if (visited[currentId] || !modules[currentId]) {
+      continue;
+    }
+
+    visited[currentId] = true;
+    deps = modules[currentId].deps || [];
+    ids = ids.concat(deps.map(dep => dep.id || dep.path));
+    formattedDependencies = buildDependencies(deps);
+    result.push(`${getModuleInfo(modules[currentId], formattedDependencies)}\n${currentId}:[ ${wrapSource(modules[currentId])}, ${formattedDependencies}]`);
+  }
+
+  return `{\n${result.join(",\n")}\n}`;
+}
+
+function wrapSource(mod) {
+  return `function(${requireName}, module, exports) {\n${renameRequire(mod)}\n}`;
+}
+
+function renameRequire(mod) {
+  const ast = acorn.parse(mod.source);
+
+  walk.simple(ast, {
+    CallExpression: (node) => {
+      if (node.callee.name === "require") {
+        node.callee.name = requireName;
+      }
+    }
+  });
+
+  return escodegen.generate(ast);
+}
+
+function buildDependencies(dependencies) {
+  return "{" + dependencies.map(dependency => (`"${dependency.name}": ${dependency.id ? dependency.id : addQuotes(dependency.path)}`)).join(", ") + "}";
+}
+
+function buildEntries(entries) {
+  return `[${entries.join(", ")}]`;
+}
+
+function getEntries(modules) {
+  return Object
+    .keys(modules)
+    .filter(key => modules[key].entry)
+    .map(key => key);
+}
+
+function addQuotes(item) {
+  return `"${item}"`;
+}
+
+function getModuleInfo(mod, deps) {
+  return (
+`/**
+ * id: ${mod.id}
+ * path: ${mod.path.replace(cwd, "")}
+ * deps: ${deps}
+ */`
+  );
+}
+
+module.exports.buildBundle = buildBundle;

--- a/src/bundle/app-bundle-builder.js
+++ b/src/bundle/app-bundle-builder.js
@@ -32,22 +32,22 @@ function buildBundle(modules, options) {
     ids = ids.concat(dependencies.map(dep => dep.id || dep.path));
 
     formattedDependencies = buildDependencies(dependencies);
-    formattedPreBundle = `${buildModuleInfoComment(currentModule, formattedDependencies)}\n${id}:`;
+    formattedPreBundle = `${buildModuleInfoComment(currentModule, id, formattedDependencies)}\n${id}:`;
     lineno += lineCount(formattedPreBundle);
 
     sourceMap.addFile({
       source: currentModule.source,
-      sourceFile: currentModule.path.replace(cwd, "")
+      sourceFile: currentModule.path ? currentModule.path.replace(cwd, "") : "_anonymous.js"
     }, {
       line: lineno
     });
 
-    formattedPostBundle = `[${wrapSource(combineSourceMap.removeComments(currentModule.source))}, ${formattedDependencies}]`;
+    formattedPostBundle = `[${wrapSource(combineSourceMap.removeComments(currentModule.source))},${formattedDependencies}]`;
     lineno += lineCount(formattedPostBundle) - 1;
     result.push(formattedPreBundle + formattedPostBundle);
   }
 
-  const bundleString = `${preamble}({\n${result.join(",\n")}}, ${buildEntries(entries)});`;
+  const bundleString = `${preamble}({\n${result.join(",\n")}\n},${buildEntries(entries)});`;
   return options.umd ? umd(options.umd, `${bundleString}\nreturn ${requireName}(${entries[0]});\n${sourceMap.comment()}`) : `${bundleString}\n${sourceMap.comment()}`;
 }
 
@@ -91,11 +91,11 @@ function addQuotes(item) {
   return `"${item}"`;
 }
 
-function buildModuleInfoComment(mod, deps) {
+function buildModuleInfoComment(mod, id, deps) {
   return (
 `/**
- * id: ${mod.id}
- * path: ${mod.path.replace(cwd, "")}
+ * id: ${id}
+ * path: ${mod.path ? mod.path.replace(cwd, "") : ""}
  * deps: ${deps}
  */`
   );

--- a/src/bundle/app-bundle-prelude.js
+++ b/src/bundle/app-bundle-prelude.js
@@ -1,0 +1,37 @@
+module.exports = function(moduleMap, entries) {
+  const results = {};
+  const externalRequire = typeof require !== "undefined" && require;
+
+  function getModule(id) {
+    if (!results[id]) {
+      if (moduleMap[id]) {
+        const meta = {}; meta.exports = {};
+        const load = moduleMap[id][0];
+        const deps = moduleMap[id][1];
+        const getDependency = function(moduleName) { return getModule(deps[moduleName]); };
+
+        // This is to handle circular references gracefully.
+        results[id] = meta.exports;
+
+        // get me the module
+        load(getDependency, meta, meta.exports);
+
+        // Reassign to make sure we handle the case where module.exports
+        // was replaced with something else.
+        results[id] = meta.exports;
+      }
+      else {
+        results[id] = externalRequire && externalRequire(id);
+
+        if (!externalRequire && !results[id]) {
+          throw new Error("Module " + id + " not found");
+        }
+      }
+    }
+
+    return results[id];
+  }
+
+  entries.forEach(getModule);
+  return getModule;
+};

--- a/src/bundle/app-bundle.js
+++ b/src/bundle/app-bundle.js
@@ -35,13 +35,16 @@ function buildBundle(bundler, bundle, context, options) {
     return Promise.resolve(bundle);
   }
 
+  // Map entries first to give them lower IDs than the rest to make
+  // bundle ID generation more predictable.
+  const entries = bundle.entries.map(id => bundler.getId(id));
+
   const moduleMap = context.getModules(bundle.modules).reduce((acc, mod) => {
-    var deps = mod.deps.map(dep => Object.assign({}, dep, { id: bundler.getId(dep.path) }));
-    acc[bundler.getId(mod.path)] = Object.assign({}, mod, { id: bundler.getId(mod.path), deps: deps });
+    var modId = bundler.getId(mod.id || mod.path);
+    var deps = mod.deps.map(dep => Object.assign({}, dep, { id: bundler.getId(dep.id || dep.path) }));
+    acc[modId] = Object.assign({}, mod, { id: modId, deps: deps });
     return acc;
   }, {});
-
-  const entries = bundle.entries.map(id => bundler.getId(id));
 
   const settings = bundle.isMain ?
     Object.assign({ entries: entries }, bundler._options, options) :

--- a/src/bundle/app-bundle.js
+++ b/src/bundle/app-bundle.js
@@ -1,0 +1,53 @@
+"use strict";
+
+const utils = require("belty");
+const uniqueId = require("bit-bundler-utils/uniqueId");
+const appBundleBuilder = require("./app-bundle-builder");
+
+const defaults = {
+  "umd": false
+};
+
+class AppBundle {
+  constructor(options) {
+    this._options = Object.assign({}, defaults, options);
+    this._uniqueIdGenerator = uniqueId.create();
+  }
+
+  bundle(context, options) {
+    var deferred = [];
+  
+    context.visitBundles((bundle) => deferred.push(buildBundle(this, bundle, context, options)));
+
+    return Promise
+      .all(deferred)
+      .then(bundles => bundles.reduce((context, bundle) => context.setBundle(bundle), context));
+  }
+
+  getId(moduleId) {
+    return this._uniqueIdGenerator.getId(moduleId);
+  }
+}
+
+
+function buildBundle(bundler, bundle, context, options) {
+  if (!bundle.modules || !bundle.modules.length) {
+    return Promise.resolve(bundle);
+  }
+
+  const entries = bundle.entries.map(id => bundler.getId(id));
+
+  const moduleMap = context.getModules(bundle.modules).reduce((acc, mod) => {
+    var deps = mod.deps.map(dep => Object.assign({}, dep, { id: bundler.getId(dep.path) }));
+    acc[bundler.getId(mod.path)] = Object.assign({}, mod, { id: bundler.getId(mod.path), deps: deps });
+    return acc;
+  }, {});
+
+  const settings = bundle.isMain ?
+    Object.assign({}, bundler._options, options) :
+    Object.assign({}, utils.omit(bundler._options, ["umd"]), options);
+
+  return bundle.setContent(appBundleBuilder.buildBundle(moduleMap, entries, settings));
+}
+
+module.exports = AppBundle;

--- a/src/bundle/app-bundle.js
+++ b/src/bundle/app-bundle.js
@@ -35,19 +35,19 @@ function buildBundle(bundler, bundle, context, options) {
     return Promise.resolve(bundle);
   }
 
-  const entries = bundle.entries.map(id => bundler.getId(id));
-
   const moduleMap = context.getModules(bundle.modules).reduce((acc, mod) => {
     var deps = mod.deps.map(dep => Object.assign({}, dep, { id: bundler.getId(dep.path) }));
     acc[bundler.getId(mod.path)] = Object.assign({}, mod, { id: bundler.getId(mod.path), deps: deps });
     return acc;
   }, {});
 
-  const settings = bundle.isMain ?
-    Object.assign({}, bundler._options, options) :
-    Object.assign({}, utils.omit(bundler._options, ["umd"]), options);
+  const entries = bundle.entries.map(id => bundler.getId(id));
 
-  return bundle.setContent(appBundleBuilder.buildBundle(moduleMap, entries, settings));
+  const settings = bundle.isMain ?
+    Object.assign({ entries: entries }, bundler._options, options) :
+    Object.assign({ entries: entries }, utils.omit(bundler._options, ["umd"]), options);
+
+  return bundle.setContent(appBundleBuilder.buildBundle(moduleMap, settings));
 }
 
 module.exports = AppBundle;

--- a/src/bundle/browserpack-builder.js
+++ b/src/bundle/browserpack-builder.js
@@ -29,7 +29,7 @@ class Builder {
 
   bundle(context, options) {
     var deferred = [];
-  
+
     context.visitBundles((bundle) => deferred.push(buildBundle(this, bundle, context, options)));
 
     return Promise
@@ -41,7 +41,7 @@ class Builder {
     var bpOptions = buildBrowserPackOptions(bpBundle, buildOptions(this));
     console.log(formatBundleInfo(bpBundle, bpOptions));
   }
-  
+
   getId(moduleId) {
     return this._uniqueIdGenerator.getId(moduleId);
   }

--- a/src/bundler/index.js
+++ b/src/bundler/index.js
@@ -2,7 +2,8 @@
 
 var utils = require("belty");
 var types = require("dis-isa");
-var BundleBuilder = require("../bundle/builder");
+var AppBundle = require("../bundle/app-bundle");
+// var BrowserpackBuilder = require("../bundle/browserpack-builder");
 var configurator = require("setopt")();
 var pluginLoader = require("../pluginLoader");
 
@@ -12,7 +13,8 @@ class Bundler {
     this._postbundle = [];
 
     if (!options.provider) {
-      options.provider = new BundleBuilder(options);
+      options.provider = new AppBundle(options);
+      // options.provider = new BrowserpackBuilder(options);
     }
 
     configurator.configure(this, options);

--- a/src/context.js
+++ b/src/context.js
@@ -91,7 +91,10 @@ class Context {
 
   setCache(cache) {
     return this.configure({
-      cache: Object.keys(cache).filter(id => this.exclude.indexOf(id) === -1).reduce((accumulator, id) => (accumulator[id] = cache[id], accumulator), {})
+      cache: Object
+        .keys(cache)
+        .filter(id => this.exclude.indexOf(id) === -1)
+        .reduce((accumulator, id) => (accumulator[id] = cache[id], accumulator), {})
     });
   }
 

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -1,1 +1,2 @@
 import "./spec/index";
+import "./spec/bundle/app-bundle-builder";

--- a/test/helpers/wrapModule.js
+++ b/test/helpers/wrapModule.js
@@ -1,0 +1,18 @@
+module.exports = function wrapModule(content, id, deps, path) {
+  var formattedDeps = "{" +
+  Object.keys(deps || {}).reduce((acc, dep) => {
+    acc.push(`"${dep}": ${deps[dep]}`);
+    return acc;
+  }, []).join(", ") +
+  "}";
+
+  return (
+`/**
+ * id: ${id}
+ * path: ${path ? path : ""}
+ * deps: ${formattedDeps}
+ */
+${id}:[function(_bb$req, module, exports) {
+${content.replace(/\brequire\b/g, "_bb$req")}
+},${formattedDeps}]`);
+};

--- a/test/spec/bundle/app-bundle-builder.js
+++ b/test/spec/bundle/app-bundle-builder.js
@@ -1,0 +1,81 @@
+import wrapModule from "../..//helpers/wrapModule";
+import appBundleBuilder from "../../../src/bundle/app-bundle-builder";
+import appBundlePrelude from "../../../src/bundle/app-bundle-prelude";
+import combineSourceMap from "combine-source-map";
+import { expect } from "chai";
+
+const prelude = appBundlePrelude.toString();
+
+describe("Bundle builder test suite", function() {
+  describe("When bundling a hello world module with no entry", function() {
+    var input, result;
+
+    beforeEach(function() {
+      input = "module.exports = console.log('hello world');";
+
+      result = appBundleBuilder.buildBundle({
+        1: { source: input }
+      });
+    });
+
+    it("then the bundler generates the correct result", function() {
+      var expected = (
+`require=_bb$req=(${prelude})({
+${wrapModule(input, 1)}
+},[]);
+`);
+      expect(combineSourceMap.removeComments(result)).to.equal(expected);
+    });
+  });
+
+  describe("When bundling a hello world module with an entry", function() {
+    var input, result;
+
+    beforeEach(function() {
+      input = "module.exports = console.log('hello world');";
+
+      result = appBundleBuilder.buildBundle({
+        1: { source: input, entry: true }
+      });
+    });
+
+    it("then the bundler generates the correct result", function() {
+      var expected = (
+`require=_bb$req=(${prelude})({
+${wrapModule(input, 1)}
+},[1]);
+`);
+
+      expect(combineSourceMap.removeComments(result)).to.equal(expected);
+    });
+  });
+
+
+  describe("When bundling a hello world module with an entry and two dependency", function() {
+    var input, dep1, dep2, result;
+
+    beforeEach(function() {
+      input = "require('path');require('process');module.exports = console.log('hello world');";
+      dep1 = "console.log('the path');";
+      dep2 = "console.log('the process');";
+
+      result = appBundleBuilder.buildBundle({
+        1: { source: input, entry: true, deps: [{ id: 2, name: "path" }, { id: 3, name: "process" }] },
+        2: { source: dep1 },
+        3: { source: dep2 }
+      });
+    });
+
+    it("then the bundler generates the correct result", function() {
+      var expected = (
+`require=_bb$req=(${prelude})({
+${wrapModule(input, 1, {"path": 2, "process": 3})},
+${wrapModule(dep1, 2)},
+${wrapModule(dep2, 3)}
+},[1]);
+`);
+
+      expect(combineSourceMap.removeComments(result)).to.equal(expected);
+    });
+  });
+});

--- a/test/spec/index.js
+++ b/test/spec/index.js
@@ -493,13 +493,6 @@ function createMockContext() {
   return context;
 }
 
-function trimResult(data) {
-  return data
-    .toString()
-    .replace(/\n/g, "")
-    .replace(/\/\/# sourceMappingURL=.*/, "");
-}
-
 function arrayItemContains(value) {
   return function(array) {
     return array.find(function(str) {

--- a/test/spec/index.js
+++ b/test/spec/index.js
@@ -3,7 +3,13 @@
 import { expect } from "chai";
 import sinon from "sinon";
 import path from "path";
+import combineSourceMap from "combine-source-map";
 import BitBundler from "../../src/index";
+import wrapModule from "../helpers/wrapModule";
+import appBundlePrelude from "../../src/bundle/app-bundle-prelude";
+import fs from "fs";
+
+const prelude = appBundlePrelude.toString();
 
 describe("BitBundler test suite", function() {
   var createBundler, bitbundler;
@@ -23,6 +29,9 @@ describe("BitBundler test suite", function() {
 
     describe("and bundling a module with a couple of dependencies and no bundle destination", function() {
       var result;
+      const entry = fs.readFileSync("test/sample/X.js").toString().replace(/require/g, "_bb$req");
+      const dep2 = fs.readFileSync("test/sample/Y.js").toString().replace(/require/g, "_bb$req");
+      const dep3 = fs.readFileSync("test/sample/z.js").toString().replace(/require/g, "_bb$req");
 
       beforeEach(function() {
         return bitbundler.bundle("test/sample/X.js").then(function(ctx) {
@@ -31,7 +40,14 @@ describe("BitBundler test suite", function() {
       });
 
       it("then result in the main bundle contains correct content", function() {
-        expect(trimResult(result.getBundles("main").content)).to.be.equal(`require=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){/*eslint no-console: ["off"]*/var Y = require("./Y");function X() {  console.log("Say X");  this._y = new Y();}module.exports = new X();},{"./Y":2}],2:[function(require,module,exports){/*eslint no-console: ["off"]*/var z = require("./z");var X = require("./X");function Y() {  console.log(X, typeof X);  console.log("Say Y");  z.potatoes();}module.exports = Y;},{"./X":1,"./z":3}],3:[function(require,module,exports){/*eslint no-console: ["off"]*/module.exports = {  roast: "this",  potatoes: function() {    console.log("Say potatoes");  }};},{}]},{},[1])`);
+        var expected = (
+`require=_bb$req=(${prelude})({
+${wrapModule(entry, 1, {"./Y": 2}, "/test/sample/X.js")},
+${wrapModule(dep2, 2, {"./z": 3, "./X": 1}, "/test/sample/Y.js")},
+${wrapModule(dep3, 3, {}, "/test/sample/z.js")}
+},[1]);
+`);
+        expect(combineSourceMap.removeComments(result.getBundles("main").content.toString())).to.be.equal(expected);
       });
 
       it("then the main bundle has the dest set to false", function() {
@@ -41,6 +57,9 @@ describe("BitBundler test suite", function() {
 
     describe("and bundling a module with a couple of dependencies with a bundle destination", function() {
       var result;
+      const entry = fs.readFileSync("test/sample/X.js").toString().replace(/require/g, "_bb$req");
+      const dep2 = fs.readFileSync("test/sample/Y.js").toString().replace(/require/g, "_bb$req");
+      const dep3 = fs.readFileSync("test/sample/z.js").toString().replace(/require/g, "_bb$req");
 
       beforeEach(function() {
         return bitbundler.bundle({ src: "test/sample/X.js", dest: "test/dist/dest-test-bundle.js" }).then(function(ctx) {
@@ -49,7 +68,15 @@ describe("BitBundler test suite", function() {
       });
 
       it("then result contains correct bundle content", function() {
-        expect(trimResult(result.getBundles("main").content)).to.be.equal(`require=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){/*eslint no-console: ["off"]*/var Y = require("./Y");function X() {  console.log("Say X");  this._y = new Y();}module.exports = new X();},{"./Y":2}],2:[function(require,module,exports){/*eslint no-console: ["off"]*/var z = require("./z");var X = require("./X");function Y() {  console.log(X, typeof X);  console.log("Say Y");  z.potatoes();}module.exports = Y;},{"./X":1,"./z":3}],3:[function(require,module,exports){/*eslint no-console: ["off"]*/module.exports = {  roast: "this",  potatoes: function() {    console.log("Say potatoes");  }};},{}]},{},[1])`);
+        var expected = (
+`require=_bb$req=(${prelude})({
+${wrapModule(entry, 1, {"./Y": 2}, "/test/sample/X.js")},
+${wrapModule(dep2, 2, {"./z": 3, "./X": 1}, "/test/sample/Y.js")},
+${wrapModule(dep3, 3, {}, "/test/sample/z.js")}
+},[1]);
+`);
+
+        expect(combineSourceMap.removeComments(result.getBundles("main").content.toString())).to.be.equal(expected);
       });
 
       it("then the main bundle has the dest set to correct full path", function() {


### PR DESCRIPTION
This PR introduced a bundle build replacement for browser-pack. The primary for the replacement is that i needed a way to change the signature of the method wrapping each module to use something other than `require`. This is needed in order to better handle bundling modules that export bundled code and make use of `require`, which causes dependencies to be incorrectly reprocessed and in some cases generate bad bundles.  Also - the new bundle builder has a much more compatible interface to what bit-bundler generates, so there is a lot less code just to convert module formats.

- [x] add replacement for browser-pack
- [x] write unit tests for new bundle builder
- [x] update all broken unit test due to differences in the bundles being created
- [x] integration tests with packages that export bundles with `require` functions in them
- [x] integrate source maps

Future work is to generate bundles with a single wrapping function for all modules rather than one wrapping function per module