### PR TITLE
adding default empty entries array in bundle to make sure splits dont…

### DIFF
--- a/src/bundle/app-bundle-builder.js
+++ b/src/bundle/app-bundle-builder.js
@@ -48,7 +48,7 @@ function buildBundle(modules, options) {
   }
 
   const bundleString = `${preamble}({\n${result.join(",\n")}\n},${buildEntries(entries)});`;
-  return options.umd ? umd(options.umd, `${bundleString}\nreturn ${requireName}(${entries[0]});\n${sourceMap.comment()}`) : `${bundleString}\n${sourceMap.comment()}`;
+  return options.umd ? umd(options.umd, `${bundleString}\nreturn ${requireName}(${entries[0]});\n${sourceMap.comment()}\n`) : `${bundleString}\n${sourceMap.comment()}\n`;
 }
 
 function wrapSource(source) {

--- a/src/bundle/index.js
+++ b/src/bundle/index.js
@@ -18,7 +18,7 @@ class Bundle {
       dest = dest !== false && looksLikeFileName(name) ? name : false;
     }
 
-    Object.assign(this, options, { name: name, dest: dest });
+    Object.assign(this, { entries: [] }, options, { name: name, dest: dest });
   }
 
   configure(options) {

--- a/test/spec/bundle/app-bundle-builder.js
+++ b/test/spec/bundle/app-bundle-builder.js
@@ -23,6 +23,7 @@ describe("Bundle builder test suite", function() {
 `require=_bb$req=(${prelude})({
 ${wrapModule(input, 1)}
 },[]);
+
 `);
       expect(combineSourceMap.removeComments(result)).to.equal(expected);
     });
@@ -44,6 +45,7 @@ ${wrapModule(input, 1)}
 `require=_bb$req=(${prelude})({
 ${wrapModule(input, 1)}
 },[1]);
+
 `);
 
       expect(combineSourceMap.removeComments(result)).to.equal(expected);
@@ -73,6 +75,7 @@ ${wrapModule(input, 1, {"path": 2, "process": 3})},
 ${wrapModule(dep1, 2)},
 ${wrapModule(dep2, 3)}
 },[1]);
+
 `);
 
       expect(combineSourceMap.removeComments(result)).to.equal(expected);

--- a/test/spec/index.js
+++ b/test/spec/index.js
@@ -46,6 +46,7 @@ ${wrapModule(entry, 1, {"./Y": 2}, "/test/sample/X.js")},
 ${wrapModule(dep2, 2, {"./z": 3, "./X": 1}, "/test/sample/Y.js")},
 ${wrapModule(dep3, 3, {}, "/test/sample/z.js")}
 },[1]);
+
 `);
         expect(combineSourceMap.removeComments(result.getBundles("main").content.toString())).to.be.equal(expected);
       });
@@ -74,6 +75,7 @@ ${wrapModule(entry, 1, {"./Y": 2}, "/test/sample/X.js")},
 ${wrapModule(dep2, 2, {"./z": 3, "./X": 1}, "/test/sample/Y.js")},
 ${wrapModule(dep3, 3, {}, "/test/sample/z.js")}
 },[1]);
+
 `);
 
         expect(combineSourceMap.removeComments(result.getBundles("main").content.toString())).to.be.equal(expected);


### PR DESCRIPTION
… cause crashes when they dont specify entries