### PR TITLE
various perf/error handling improvements

### DIFF
--- a/src/bundle/app-bundle-builder.js
+++ b/src/bundle/app-bundle-builder.js
@@ -5,7 +5,8 @@ const combineSourceMap = require("combine-source-map");
 const umd = require("umd");
 const prelude = require("./app-bundle-prelude").toString();
 const requireName = "_bb$req";
-const preamble =`require=${requireName}=(${prelude})`;
+const iteratorName = "_bb$iter";
+const preamble =`${iteratorName}=(${prelude})`;
 
 function buildBundle(modules, options) {
   options = options || {};

--- a/test/spec/bundle/app-bundle-builder.js
+++ b/test/spec/bundle/app-bundle-builder.js
@@ -20,7 +20,7 @@ describe("Bundle builder test suite", function() {
 
     it("then the bundler generates the correct result", function() {
       var expected = (
-`require=_bb$req=(${prelude})({
+`_bb$iter=(${prelude})({
 ${wrapModule(input, 1)}
 },[]);
 
@@ -42,7 +42,7 @@ ${wrapModule(input, 1)}
 
     it("then the bundler generates the correct result", function() {
       var expected = (
-`require=_bb$req=(${prelude})({
+`_bb$iter=(${prelude})({
 ${wrapModule(input, 1)}
 },[1]);
 
@@ -70,7 +70,7 @@ ${wrapModule(input, 1)}
 
     it("then the bundler generates the correct result", function() {
       var expected = (
-`require=_bb$req=(${prelude})({
+`_bb$iter=(${prelude})({
 ${wrapModule(input, 1, {"path": 2, "process": 3})},
 ${wrapModule(dep1, 2)},
 ${wrapModule(dep2, 3)}

--- a/test/spec/index.js
+++ b/test/spec/index.js
@@ -41,7 +41,7 @@ describe("BitBundler test suite", function() {
 
       it("then result in the main bundle contains correct content", function() {
         var expected = (
-`require=_bb$req=(${prelude})({
+`_bb$iter=(${prelude})({
 ${wrapModule(entry, 1, {"./Y": 2}, "/test/sample/X.js")},
 ${wrapModule(dep2, 2, {"./z": 3, "./X": 1}, "/test/sample/Y.js")},
 ${wrapModule(dep3, 3, {}, "/test/sample/z.js")}
@@ -70,7 +70,7 @@ ${wrapModule(dep3, 3, {}, "/test/sample/z.js")}
 
       it("then result contains correct bundle content", function() {
         var expected = (
-`require=_bb$req=(${prelude})({
+`_bb$iter=(${prelude})({
 ${wrapModule(entry, 1, {"./Y": 2}, "/test/sample/X.js")},
 ${wrapModule(dep2, 2, {"./z": 3, "./X": 1}, "/test/sample/Y.js")},
 ${wrapModule(dep3, 3, {}, "/test/sample/z.js")}


### PR DESCRIPTION
1. improved a bit of performance for loading modules from different bundles by keeping the call stack smaller when searching for modules in bundles
2. added better error reported by specifying which module name failed to load.
3. generating better stack traces that show which bundle was trying to load the dependency