### PR TITLE
implemented the ability to export modules by name from a bundle

### DIFF
--- a/src/bundler/chunkedBundle.js
+++ b/src/bundler/chunkedBundle.js
@@ -3,6 +3,7 @@
 const utils = require("belty");
 const uniqueId = require("bit-bundler-utils/uniqueId");
 const chunkedBundleBuilder = require("./chunkedBundleBuilder");
+const configureExportName = require("./exportNames");
 
 const defaults = {
   "umd": false
@@ -27,6 +28,10 @@ class ChunkedBundle {
   getId(moduleId) {
     return this._uniqueIdGenerator.getId(moduleId);
   }
+
+  setId(moduleId, value) {
+    this._uniqueIdGenerator.setId(moduleId, value);
+  }
 }
 
 
@@ -35,13 +40,18 @@ function buildBundle(bundler, bundle, context, options) {
     return Promise.resolve(bundle);
   }
 
+  options = options || {};
+  const getId = (mod) => bundler.getId(mod.id);
+  const exportName = configureExportName(bundler, bundle.isMain ? bundler._options.exportNames : options.exportNames);
+
   // Map entries first to give them lower IDs than the rest to make
   // bundle ID generation more predictable.
-  const entries = bundle.entries.map(id => bundler.getId(id));
+  const entries = context.getModules(bundle.entries).map(mod => (exportName(mod), getId(mod)));
 
   const moduleMap = context.getModules(bundle.modules).reduce((acc, mod) => {
-    var modId = bundler.getId(mod.id || mod.path);
-    var deps = mod.deps.map(dep => Object.assign({}, dep, { id: bundler.getId(dep.id || dep.path) }));
+    exportName(mod);
+    var modId = getId(mod);
+    var deps = mod.deps.map(dep => Object.assign({}, dep, { id: (exportName(dep), getId(dep)) }));
     acc[modId] = Object.assign({}, mod, { id: modId, deps: deps });
     return acc;
   }, {});
@@ -52,5 +62,6 @@ function buildBundle(bundler, bundle, context, options) {
 
   return bundle.setContent(chunkedBundleBuilder.buildBundle(moduleMap, settings));
 }
+
 
 module.exports = ChunkedBundle;

--- a/src/bundler/exportNames.js
+++ b/src/bundler/exportNames.js
@@ -1,0 +1,24 @@
+function configureExportName(bundler, exportNames) {
+  if (!exportNames) {
+    return () => {};
+  }
+
+  var exportedNames = (
+    exportNames === true ? true :
+    Array.isArray(exportNames) ? exportNames.reduce((acc, item) => (acc[item] = item, acc), {}) :
+    exportNames
+  );
+
+  var processed = {};
+
+  return function(mod) {
+    var name = exportedNames === true && /^\w/.test(mod.name) ? mod.name : exportedNames[mod.name];
+
+    if (name && !processed[mod.id]) {
+      processed[mod.id] = true;
+      bundler.setId(mod.id, JSON.stringify(name));
+    }
+  };
+}
+
+module.exports = configureExportName;

--- a/src/bundler/options.js
+++ b/src/bundler/options.js
@@ -7,5 +7,5 @@ module.exports = function(options) {
     };
   }
 
-  return Object.assign(utils.pick(options, ["umd", "sourceMap"]), options.bundler);
+  return Object.assign(utils.pick(options, ["umd", "sourceMap", "exportNames"]), options.bundler);
 };

--- a/test/helpers/readModule.js
+++ b/test/helpers/readModule.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+
+function fromFilePath(filePath) {
+  return fs.readFileSync(filePath).toString();
+}
+
+function fromModuleName(moduleName) {
+  return fs.readFileSync(require.resolve(moduleName)).toString();
+}
+
+module.exports.fromFilePath = fromFilePath;
+module.exports.fromModuleName = fromModuleName;

--- a/test/helpers/wrapModule.js
+++ b/test/helpers/wrapModule.js
@@ -1,7 +1,7 @@
 module.exports = function wrapModule(content, id, deps, path) {
   var formattedDeps = "{" +
   Object.keys(deps || {}).reduce((acc, dep) => {
-    acc.push(`"${dep}": ${deps[dep]}`);
+    acc.push(`"${dep}": ${JSON.stringify(deps[dep])}`);
     return acc;
   }, []).join(", ") +
   "}";
@@ -13,6 +13,6 @@ module.exports = function wrapModule(content, id, deps, path) {
  * deps: ${formattedDeps}
  */
 ${id}:[function(_bb$req, module, exports) {
-${content.replace(/\brequire\b/g, "_bb$req")}
+${content.replace(/\brequire\b\s*\(/g, "_bb$req(")}
 },${formattedDeps}]`);
 };

--- a/test/sample/z.js
+++ b/test/sample/z.js
@@ -1,4 +1,6 @@
 /*eslint no-console: ["off"]*/
+require("spromise/dist/spromise.min");
+
 module.exports = {
   roast: "this",
   potatoes: function() {


### PR DESCRIPTION
This makes it possible to create a bundle and then call the `require` using the module name, which would otherwise be some generated ID that is not idiomatic.