### PR TITLE
Bundler sourcetype module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "11.0.1",
   "dependencies": {
     "acorn": "^5.3.0",
+    "acorn-dynamic-import": "^3.0.0",
     "belty": "^5.2.1",
     "bit-bundler-utils": "^5.1.2",
     "bit-loader": "^9.2.1",

--- a/src/bundler/chunkedBundleBuilder.js
+++ b/src/bundler/chunkedBundleBuilder.js
@@ -58,7 +58,10 @@ function wrapSource(source) {
 
 function renameRequire(source) {
   const result = source.split("");
-  const ast = acorn.parse(source);
+  const ast = acorn.parse(source, {
+    sourceType: "module"
+  });
+
   var offset = 0;
 
   walk.simple(ast, {

--- a/src/bundler/chunkedBundleBuilder.js
+++ b/src/bundler/chunkedBundleBuilder.js
@@ -62,6 +62,10 @@ function wrapSource(source) {
 }
 
 function renameRequire(source) {
+  if (!source.match(/\brequire\b\s*\(/)) {
+    return source;
+  }
+
   const result = source.split("");
   const ast = acorn.parse(source, {
     sourceType: "module",

--- a/test/spec/bundler/chunkedBundleBuilder.js
+++ b/test/spec/bundler/chunkedBundleBuilder.js
@@ -81,4 +81,31 @@ ${wrapModule(dep2, 3)}
       expect(combineSourceMap.removeComments(result)).to.equal(expected);
     });
   });
+
+  describe("When bundling a hello world module with an ES6 dependency", function() {
+    var input, dep1, result;
+
+    beforeEach(function() {
+      input = "import './X';\nimport('./X');\nexport default 'hello world';";
+      dep1 = "console.log('from X.js');";
+
+      result = chunkedBundleBuilder.buildBundle({
+        1: { source: input, entry: true, deps: [{ id: 2, name: "./X" }] },
+        2: { source: dep1 }
+      });
+    });
+
+    it("then the bundler generates the correct result", function() {
+      var expected = (
+`require=_bb$iter=(${prelude})({
+${wrapModule(input, 1, {"./X": 2})},
+${wrapModule(dep1, 2)}
+},[1]);
+
+`);
+
+      expect(combineSourceMap.removeComments(result)).to.equal(expected);
+    });
+  });
+  
 });


### PR DESCRIPTION
Adding logic in the bundle generator to handle ES module syntax including dynamic imports so that non-transpiled modules continue to work.  I have also added a new check to make sure to only process modules with `require` calls before parsing the source file.