### PR TITLE
fixed issue with CLI nor properly handling nameless arguments that sh…

### DIFF
--- a/docs/HelloWorld.md
+++ b/docs/HelloWorld.md
@@ -8,19 +8,10 @@ The smallest setup would be bit-bundler with no options and bundle a file.
 $ npm install bit-bundler -g
 ```
 
-#### setup .bitbundler.js
-
-``` javascript
-module.exports = {
-  src: "src/main.js",
-  dest: "dist/out.js"
-};
-```
-
 #### run bitbundler
 
 ```
-$ bitbundler
+$ bitbundler --src src/main.js --dest dist/out.js
 ```
 
 That's it. That will bundle `src/main.js` and put the result in `dist/out.js`. But this is not really as interesting as it could be. In the next section we are going to setup a couple of loader plugins to enable features such as transpilation and linting.

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -9,6 +9,11 @@ const cammelCaseKeys = require("../cammelCaseKeys");
 module.exports = function parseCliOptions(args) {
   const cliOptions = cammelCaseKeys(subarg(args || []), { ignore: "notifications" });
   const options = Object.assign({}, defaults, cliOptions);
+
+  if (cliOptions._.length) {
+    cliOptions.src = cliOptions.src ? [].concat(cliOptions._, cliOptions.src) : cliOptions._;
+    cliOptions._ = [];
+  }
   
   try {
     var configFilePath = path.join(process.cwd(), options.config);
@@ -27,7 +32,7 @@ module.exports = function parseCliOptions(args) {
 
   return type.coerceValues(processDeprecated(options), {
     "config": type.String,
-    "src": type.Array.withTransform(configureSrc),
+    "src": type.Array.withTransform(toArray),
     "dest": type.String,
     "baseUrl": type.String,
     "stubNotFound": type.Boolean,
@@ -39,10 +44,6 @@ module.exports = function parseCliOptions(args) {
     "multiprocess": type.Any.withTransform(toNumberOrBoolean),
     "log": type.Any.withTransform(maybeBoolean)
   });
-
-  function configureSrc(src) {
-    return options._.length ? options._ : toArray(src);
-  }
   
   function toArray(value) {
     return value && value._ ? value._ : [].concat(value);


### PR DESCRIPTION
…ould be treated as filenames

the changes fix an issue where calling `bitbundler src/main.js` would not bundle `src/main.js`.