### PR TITLE
Migration to bit org step 2

### DIFF
--- a/examples/cache/package.json
+++ b/examples/cache/package.json
@@ -16,7 +16,7 @@
     "log2console": "^1.0.3"
   },
   "devDependencies": {
-    "bit-bundler": "latest",
+    "@bit/bundler": "latest",
     "@bit/loader-babel": "latest",
     "@bit/loader-cache": "latest",
     "elasticsearch": "^13.1.1",

--- a/examples/dependencies/package.json
+++ b/examples/dependencies/package.json
@@ -14,7 +14,7 @@
     "log2console": "^1.0.3"
   },
   "devDependencies": {
-    "bit-bundler": "latest",
+    "@bit/bundler": "latest",
     "source-map-explorer": "^1.3.3"
   }
 }

--- a/examples/eslint/package.json
+++ b/examples/eslint/package.json
@@ -14,7 +14,7 @@
     "log2console": "^1.0.3"
   },
   "devDependencies": {
-    "bit-bundler": "latest",
+    "@bit/bundler": "latest",
     "@bit/loader-eslint": "^1.2.0",
     "source-map-explorer": "^1.3.3"
   }

--- a/examples/from-contents/package.json
+++ b/examples/from-contents/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "bit-bundler": "latest",
+    "@bit/bundler": "latest",
     "source-map-explorer": "^1.3.3"
   }
 }

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "bit-bundler": "latest",
+    "@bit/bundler": "latest",
     "source-map-explorer": "^1.3.3"
   }
 }

--- a/examples/loggers/.bitbundler.js
+++ b/examples/loggers/.bitbundler.js
@@ -1,6 +1,6 @@
-var loggers = require("bit-bundler/loggers");
-var verboseLogger = require("bit-bundler/loggers/verbose");
-var loaderFilter = require("bit-bundler/loggers/loaderFilter");
+var loggers = require("@bit/bundler/loggers");
+var verboseLogger = require("@bit/bundler/loggers/verbose");
+var loaderFilter = require("@bit/bundler/loggers/loaderFilter");
 
 module.exports = {
   log: loggers.sequence(loaderFilter(), verboseLogger()),

--- a/examples/loggers/package.json
+++ b/examples/loggers/package.json
@@ -14,7 +14,7 @@
     "log2console": "^1.0.3"
   },
   "devDependencies": {
-    "bit-bundler": "latest",
+    "@bit/bundler": "latest",
     "source-map-explorer": "^1.3.3"
   }
 }

--- a/examples/logstash/.bitbundler.js
+++ b/examples/logstash/.bitbundler.js
@@ -1,5 +1,5 @@
-const loggers = require("bit-bundler/loggers");
-const loaderFilter = require("bit-bundler/loggers/loaderFilter");
+const loggers = require("@bit/bundler/loggers");
+const loaderFilter = require("@bit/bundler/loggers/loaderFilter");
 const JSONStream = require("JSONStream");
 const net = require("net");
 

--- a/examples/logstash/package.json
+++ b/examples/logstash/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "JSONStream": "^1.3.1",
-    "bit-bundler": "latest"
+    "@bit/bundler": "latest"
   }
 }

--- a/examples/minify/package.json
+++ b/examples/minify/package.json
@@ -14,7 +14,7 @@
     "log2console": "^1.0.3"
   },
   "devDependencies": {
-    "bit-bundler": "latest",
+    "@bit/bundler": "latest",
     "@bit/bundler-extractsm": "latest",
     "@bit/bundler-minifyjs": "latest",
     "@bit/bundler-splitter": "latest",

--- a/examples/multiprocess/package.json
+++ b/examples/multiprocess/package.json
@@ -14,7 +14,7 @@
     "log2console": "^1.0.3"
   },
   "devDependencies": {
-    "bit-bundler": "latest",
+    "@bit/bundler": "latest",
     "@bit/bundler-splitter": "latest",
     "source-map-explorer": "^1.3.3"
   }

--- a/examples/splitter/package.json
+++ b/examples/splitter/package.json
@@ -15,7 +15,7 @@
     "log2console": "^1.0.3"
   },
   "devDependencies": {
-    "bit-bundler": "latest",
+    "@bit/bundler": "latest",
     "@bit/bundler-splitter": "latest",
     "source-map-explorer": "^1.3.3"
   }

--- a/examples/watch/.bitbundler.js
+++ b/examples/watch/.bitbundler.js
@@ -1,6 +1,6 @@
-var loggers = require("bit-bundler/loggers");
-var buildstatsLogger = require("bit-bundler/loggers/buildstats");
-var watchLogger = require("bit-bundler/loggers/watch");
+var loggers = require("@bit/bundler/loggers");
+var buildstatsLogger = require("@bit/bundler/loggers/buildstats");
+var watchLogger = require("@bit/bundler/loggers/watch");
 
 module.exports = {
   // Enable watching. You can alternatively pass

--- a/examples/watch/package.json
+++ b/examples/watch/package.json
@@ -13,6 +13,6 @@
     "log2console": "^1.0.3"
   },
   "devDependencies": {
-    "bit-bundler": "latest"
+    "@bit/bundler": "latest"
   }
 }

--- a/examples/webapp/package.json
+++ b/examples/webapp/package.json
@@ -22,7 +22,7 @@
     "3dub": "^0.5.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
-    "bit-bundler": "latest",
+    "@bit/bundler": "latest",
     "@bit/bundler-extractsm": "latest",
     "@bit/bundler-minifyjs": "latest",
     "@bit/bundler-splitter": "latest",


### PR DESCRIPTION
Updating examples to use `@bit/bundler` as I prepare to publish to npm bit-bundler under the bit org.