### PR TITLE
fixed issues with the buildstat logging stream

### DIFF
--- a/loggers/buildstats.js
+++ b/loggers/buildstats.js
@@ -15,8 +15,8 @@ function buildstatsStreamFactory(options) {
   var logEnabled = !(options === false);
   var settings = options || {};
   var level = logger.levels[settings.level || "warn"];
-  var stdoutOverride = overrideStream(process.stdout).override();
-  var stderrOverride = overrideStream(process.stderr).override();
+  var stdoutOverride = createStreamOverride(process.stdout).override();
+  var stderrOverride = createStreamOverride(process.stderr).override();
   var startTime, spinner;
 
   return es.through(function(chunk) {
@@ -59,21 +59,15 @@ function buildstatsStreamFactory(options) {
     this.emit("data", chunk);
   });
 
-  function overrideStream(stream) {
-    var overrideHandle = overrideStreamWrite(stream, function(data, encoding, cb) {
-      overrideHandle.restore();
-
+  function createStreamOverride(stream) {
+    return overrideStreamWrite(stream, function(data, encoding, cb) {
       if (spinner) {
         writeSpinner(spinner, data, null, 4);
       }
       else {
         stream.write(data, encoding, cb);
       }
-
-      overrideHandle.override();
     });
-
-    return overrideHandle;
   }
 }
 
@@ -122,7 +116,6 @@ function writeSpinner(spinner, text, htime, level) {
   else {
     spinner.clear();
     writeStream(spinner.stream, text, level);
-    spinner.render();
   }
 }
 


### PR DESCRIPTION
Migrating from ora 1 to 3 introduced a couple of small changes within Ora that caused things like string getting written twice because of calling `render` after writing to the stream.  In ora 1 it basically caused the string to be rendered twice overriding the first one.  In ora 3, the string get appended causing strings to be repeated at times.